### PR TITLE
Python3 fix

### DIFF
--- a/library/drumhat.py
+++ b/library/drumhat.py
@@ -7,7 +7,7 @@ dh = cap1xxx.Cap1188(
 
 auto_leds = True
 
-PADS = range(1,9)
+PADS = list(range(1,9))
 
 LEDMAP = [
     5, 4, 3, 2,


### PR DESCRIPTION
Under Python3 I got the error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/drumhat.py", line 34, in on_hit
    channel = NUMMAP.index(pad)
ValueError: range(1, 9) is not in list

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "Pimoroni/drumhat/test.py", line 10, in <module>
    drumhat.on_hit(drumhat.PADS, hit_handler)
  File "/usr/local/lib/python3.4/dist-packages/drumhat.py", line 36, in on_hit
    raise TypeError("Invalid drum pad #{}".format(pad))
TypeError: Invalid drum pad #range(1, 9)
```
