### PR TITLE
Fix CHANGELOG versions

### DIFF
--- a/library/CHANGELOG.txt
+++ b/library/CHANGELOG.txt
@@ -1,4 +1,4 @@
-0.0.3
+0.0.4
 
 * Python 3 fix, thanks @lurch
 


### PR DESCRIPTION
You've just pushed 0.0.4 which includes my Python3-fix, but you didn't add any comments to the CHANGELOG for the previous 0.0.3 release
