### PR TITLE
Typo

### DIFF
--- a/library/drumhat.py
+++ b/library/drumhat.py
@@ -23,7 +23,7 @@ _on_press = [None] * 8
 _on_release = [None] * 8
 
 def on_hit(pad, handler=None):
-    global _on_presss
+    global _on_press
 
     if type(pad) == list:
         for ch in pad:


### PR DESCRIPTION
I think the code as-is was working due to `_on_press` being an array, and therefore the `global` statement isn't strictly necessary as you're only modifying _elements_ of the array, and not re-assigning the array itself
