### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/drumhat.py
+++ b/library/drumhat.py
@@ -4,13 +4,11 @@ from sys import exit
 try:
     import cap1xxx
 except ImportError:
-    exit("This library requires the cap1xxx module\nInstall with: sudo pip install cap1xxx")
+    raise ImportError("This library requires the cap1xxx module\nInstall with: sudo pip install cap1xxx")
 
 __version__ = '0.0.5'
 
-dh = cap1xxx.Cap1188(
-    i2c_addr=0x2c,
-    alert_pin=25)
+dh = None
 
 auto_leds = True
 
@@ -28,6 +26,7 @@ NUMMAP = [
 
 _on_press = [None] * 8
 _on_release = [None] * 8
+_is_setup = False
 
 def on_hit(pad, handler=None):
     """Register a function to be called when a pad or pads are hit.
@@ -38,6 +37,8 @@ def on_hit(pad, handler=None):
     :param handler: The handler function to call on hit
     """
     global _on_press
+
+    ensure_setup()
 
     if type(pad) == list:
         for ch in pad:
@@ -65,6 +66,8 @@ def on_release(pad, handler=None):
     :param handler: The handler function to call on release
     """
     global _on_release
+
+    ensure_setup()
 
     if type(pad) == list:
         for ch in pad:
@@ -116,6 +119,9 @@ def led_on(pad):
 
     :param pad: A single integer from 0 to 7, corresponding to the pad whose LED you want to turn on.
     """
+
+    ensure_setup()
+
     idx = -1
 
     try:
@@ -128,11 +134,17 @@ def led_on(pad):
 
 def all_off():
     """Turn off all LEDs"""
+
+    ensure_setup()
+
     for pad in PADS:
         led_off(pad)
 
 def all_on():
     """Turn on all LEDs"""
+
+    ensure_setup()
+
     for pad in PADS:
         led_on(pad)
 
@@ -141,6 +153,8 @@ def led_off(pad):
 
     :param pad: A single integer from 0 to 7, corresponding to the pad whose LED you want to turn off.
     """
+    ensure_setup()
+
     idx = -1
 
     try:
@@ -151,9 +165,26 @@ def led_off(pad):
     led = LEDMAP[idx]
     dh.set_led_state(led, False)
 
-for x in range(8):
-    dh.on(x,event='press',   handler=_handle_press)
-    dh.on(x,event='release', handler=_handle_release)
+def ensure_setup():
+    setup()
 
-"""Unlink the LEDs since Drum HAT's LEDs don't match up with the channels"""
-dh._write_byte(cap1xxx.R_LED_LINKING, 0b00000000)
+def setup():
+    global ensure_setup, dh
+
+    if _is_setup:
+        raise RuntimeError("")
+
+    def ensure_setup():
+        return True
+
+    dh = cap1xxx.Cap1188(
+        i2c_addr=0x2c,
+        alert_pin=25)
+
+    for x in range(8):
+        dh.on(x,event='press',   handler=_handle_press)
+        dh.on(x,event='release', handler=_handle_release)
+
+    """Unlink the LEDs since Drum HAT's LEDs don't match up with the channels"""
+    dh._write_byte(cap1xxx.R_LED_LINKING, 0b00000000)
+

--- a/library/drumhat.py
+++ b/library/drumhat.py
@@ -168,7 +168,7 @@ def led_off(pad):
     dh.set_led_state(led, False)
 
 def setup():
-    global dh
+    global dh, _is_setup
 
     if _is_setup:
         return True
@@ -183,4 +183,6 @@ def setup():
 
     """Unlink the LEDs since Drum HAT's LEDs don't match up with the channels"""
     dh._write_byte(cap1xxx.R_LED_LINKING, 0b00000000)
+
+    _is_setup = True
 

--- a/library/drumhat.py
+++ b/library/drumhat.py
@@ -38,7 +38,7 @@ def on_hit(pad, handler=None):
     """
     global _on_press
 
-    ensure_setup()
+    setup()
 
     if type(pad) == list:
         for ch in pad:
@@ -55,6 +55,7 @@ def on_hit(pad, handler=None):
             global _on_press
             _on_press[channel] = handler
         return decorate
+
     _on_press[channel] = handler 
 
 def on_release(pad, handler=None):
@@ -67,7 +68,7 @@ def on_release(pad, handler=None):
     """
     global _on_release
 
-    ensure_setup()
+    setup()
 
     if type(pad) == list:
         for ch in pad:
@@ -84,6 +85,7 @@ def on_release(pad, handler=None):
             global _on_release
             _on_release[channel] = handler
         return decorate
+
     _on_release[channel] = handler
 
 def _handle_press(event):
@@ -120,7 +122,7 @@ def led_on(pad):
     :param pad: A single integer from 0 to 7, corresponding to the pad whose LED you want to turn on.
     """
 
-    ensure_setup()
+    setup()
 
     idx = -1
 
@@ -135,7 +137,7 @@ def led_on(pad):
 def all_off():
     """Turn off all LEDs"""
 
-    ensure_setup()
+    setup()
 
     for pad in PADS:
         led_off(pad)
@@ -143,7 +145,7 @@ def all_off():
 def all_on():
     """Turn on all LEDs"""
 
-    ensure_setup()
+    setup()
 
     for pad in PADS:
         led_on(pad)
@@ -153,7 +155,7 @@ def led_off(pad):
 
     :param pad: A single integer from 0 to 7, corresponding to the pad whose LED you want to turn off.
     """
-    ensure_setup()
+    setup()
 
     idx = -1
 
@@ -165,16 +167,10 @@ def led_off(pad):
     led = LEDMAP[idx]
     dh.set_led_state(led, False)
 
-def ensure_setup():
-    setup()
-
 def setup():
-    global ensure_setup, dh
+    global dh
 
     if _is_setup:
-        raise RuntimeError("")
-
-    def ensure_setup():
         return True
 
     dh = cap1xxx.Cap1188(


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Drum HAT library:

* Do not perform any module setup on import
* Do not output any messages/text on import
* Use ImportError instead of hard exit() for "friendly" import error messages

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488